### PR TITLE
TypeError at operations.convert_decimalfield_value

### DIFF
--- a/firebird/operations.py
+++ b/firebird/operations.py
@@ -304,7 +304,9 @@ class DatabaseOperations(BaseDatabaseOperations):
         field = expression.field
 
         val = utils.format_number(value, field.max_digits, field.decimal_places)
-        value = decimal.Decimal.from_float(float(val))
+        
+        if val is not None:
+            value = decimal.Decimal.from_float(float(val))
         return value
 
     def convert_ipfield_value(self, value, expression, connection, context):


### PR DESCRIPTION
The method doesn't expect null values